### PR TITLE
Add Code Lux store and resale video links

### DIFF
--- a/Igorvepretski.com.html
+++ b/Igorvepretski.com.html
@@ -129,6 +129,12 @@
     <p>פרויקט קהילתי טכנולוגי לנוער בסיכון.</p>
     <a href="https://vepretski.blog/starton" style="color:#00e6ff;">לפרויקט</a>
   </div>
+  <div class="card">
+    <img src="https://cdn-icons-png.flaticon.com/512/3081/3081986.png" alt="Code Lux store icon">
+    <h3>Code Lux Store</h3>
+    <p>Official resale and projects for #7YA.</p>
+    <a href="https://replit.com/refer/igorvepretski" style="color:#00e6ff;">Visit Store</a>
+  </div>
 </section>
 
 <section>
@@ -139,6 +145,7 @@
   <iframe width="350" height="200" src="https://www.youtube.com/embed/v7158BaZkiQ" title="Igor Vepretski video 4" allowfullscreen></iframe>
   <iframe width="350" height="200" src="https://www.youtube.com/embed/U2d_hulZAC0" title="Igor Vepretski video 5" allowfullscreen></iframe>
   <iframe width="350" height="200" src="https://www.youtube.com/embed/3mG7qVapcII" title="Igor Vepretski video 6" allowfullscreen></iframe>
+  <iframe width="350" height="200" src="https://www.youtube.com/embed/jRjZjpqAgEw" title="Code Lux Store video" allowfullscreen></iframe>
 </section>
 
 <footer>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Vepretski Blog Website
 
-This repository contains the source for [Vepretski.blog](https://vepretski.blog/), the personal site of Igor Vepretski. The primary page is `Igorvepretski.com.html` and includes social links, media, and project information.
+This repository contains the source for [Vepretski.blog](https://vepretski.blog/), the personal site of Igor Vepretski. The primary page is `Igorvepretski.com.html` and includes social links, media, and project information. The site also links to the Code Lux Store for #7YA and features a resale video.
 
 ## Development
 


### PR DESCRIPTION
## Summary
- Add Code Lux Store card linking to Replit referral for #7YA resale projects
- Embed Code Lux Store promotional video in media section
- Update README with new store and video references

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e81d4edc83278763f63775fe15fd